### PR TITLE
URL 정규식 수정, README에 정오표 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <a href="http://www.yes24.com/Product/Goods/78569687"><img src="https://i.imgur.com/j03ENCc.jpg" width="500px" title="embeddings" /></a>
 
-
+- [정오표](https://ratsgo.github.io/embedding/notice.html)
 
 ### embedding methods
 

--- a/preprocess/dump.py
+++ b/preprocess/dump.py
@@ -24,7 +24,7 @@ def make_corpus(in_f, out_f):
 WIKI_REMOVE_CHARS = re.compile("'+|(=+.{2,30}=+)|__TOC__|(ファイル:).+|:(en|de|it|fr|es|kr|zh|no|fi):|\n", re.UNICODE)
 WIKI_SPACE_CHARS = re.compile("(\\s|゙|゚|　)+", re.UNICODE)
 EMAIL_PATTERN = re.compile("(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", re.UNICODE)
-URL_PATTERN = re.compile("((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$", re.UNICODE)
+URL_PATTERN = re.compile("(ftp|http|https)?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+", re.UNICODE)
 WIKI_REMOVE_TOKEN_CHARS = re.compile("(\\*$|:$|^파일:.+|^;)", re.UNICODE)
 MULTIPLE_SPACES = re.compile(' +', re.UNICODE)
 


### PR DESCRIPTION
## 정규식
저만 그런지 모르겠는데..

토크나이징만 따와서 돌려보거나 https://regex101.com/ 에
```regex
((ftp|http|https):\/\/)?(www.)?(?!.*(ftp|http|https|www.))[a-zA-Z0-9_-]+(\.[a-zA-Z]+)+((\/)[\w#]+)*(\/\w+\?[a-zA-Z0-9_]+=\w+(&[a-zA-Z0-9_]+=\w+)*)?$
```
로 테스트 해보니 잘 안되더라고요.

http://urlregex.com/ 의 정규식에 원래 의도했던대로 ftp를 추가한 정규식입니다.
```regex
(ftp|http|https)?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+
```

## 정오표
정오표는 독자들이 바로 접근할 수 있는게 좋다고 생각해서 책 이미지 바로 밑에 링크를 추가했습니다.