### PR TITLE
Add encoding

### DIFF
--- a/preprocess/dump.py
+++ b/preprocess/dump.py
@@ -9,7 +9,7 @@ https://www.kdnuggets.com/2017/11/building-wikipedia-text-corpus-nlp.html
 """
 def make_corpus(in_f, out_f):
     """Convert Wikipedia xml dump file to text corpus"""
-    output = open(out_f, 'w')
+    output = open(out_f, 'w', encoding = "utf-8")
     wiki = WikiCorpus(in_f, tokenizer_func=tokenize, dictionary=Dictionary())
     i = 0
     for text in wiki.get_texts():


### PR DESCRIPTION
위 코드를 넣지 않으면 아래와 같은 오류가 발생합니다. 'utf-8'로 인코딩 하면 문제는 해결됩니다.

Traceback (most recent call last):
  File "dump.py", line 108, in <module>
    make_corpus(args.input_path, args.output_path)
  File "dump.py", line 16, in make_corpus
    output.write(bytes(' '.join(text), 'utf-8').decode('utf-8') + '\n')
UnicodeEncodeError: 'cp949' codec can't encode character '\u2022' in position 1100: illegal multibyte sequence