### PR TITLE
directory path error - prefix /notebooks/embedding/ @ line 103

### DIFF
--- a/preprocess.sh
+++ b/preprocess.sh
@@ -103,7 +103,7 @@ case $COMMAND in
             --output_path /notebooks/embedding/data/processed/processed_korquad_train.txt
         python preprocess/dump.py --preprocess_mode korquad \
             --input_path /notebooks/embedding/data/raw/KorQuAD_v1.0_dev.json \
-            --output_path data/processed/processed_korquad_dev.txt
+            --output_path /notebooks/embedding/data/processed/processed_korquad_dev.txt
         cat /notebooks/embedding/data/processed/processed_korquad_train.txt /notebooks/embedding/data/processed/processed_korquad_dev.txt > /notebooks/embedding/data/processed/processed_korquad.txt
         rm /notebooks/embedding/data/processed/processed_korquad_*.txt
         ;;


### PR DESCRIPTION
korquad 전처리 시 path 오류 입니다.
그리고 "네이버 영화 리뷰 말뭉치" 전처리시
unable to import 'smart_open.gcs', disabling that module
오류 발생시
pip install smart_open==1.10.0
으로 downgrade하니 오류가 안뜹니다.

즐겁고 건강한 하루 ....